### PR TITLE
deploy-script-dotnet-v1

### DIFF
--- a/AssemblyInfoVersionPatcher.ps1
+++ b/AssemblyInfoVersionPatcher.ps1
@@ -1,0 +1,76 @@
+﻿Param(
+  [string]$assemblyInfoPath  
+)
+
+. $PSScriptRoot\Common.ps1
+
+$assemblyInfoName = (Get-Item $assemblyInfoPath).Name
+
+Print-Step-Header "before_build: Patching version in $assemblyInfoName"
+
+$globalAssemblyFileContent = Get-Content $assemblyInfoPath
+					
+$versionMatchPattern = '[0-9]+(\.([0-9]+|\*)){1,3}'				
+$assemblyVersionMatchPattern = "(?<major>[0-9]+)\.(?<minor>[0-9])+(\.(?<build>([0-9])))?(\.(?<revision>([0-9])))?"
+
+$hasAssemblyVersionMatchPattern = "AssemblyVersion\(`"$versionMatchPattern`"\)"
+
+$hasAssemblyVersion = "'"+$globalAssemblyFileContent+"'" -match $hasAssemblyVersionMatchPattern
+if (!$hasAssemblyVersion)
+{
+	throw "Could not get AssemblyVersion element. Have you deleted element from AssemblyInfo or moved the file? Stopping before world explodes!"	
+}
+else
+{
+	Write-Host "AssemblyVersion found, lets get this 🎉 started!"
+	$assemblyVersionFormattedCorrectly = $matches[0] -match $assemblyVersionMatchPattern	
+	if (!$assemblyVersionFormattedCorrectly) 
+	{
+		throw "The Global Assembly Version is not formatted correctly! Should be in format [major.minor.build], and optionally revision ($'$assemblyVersionMatchPattern') 😭"	    
+	}
+	
+	$major=$matches['major'] -as [int]
+	$minor=$matches['minor'] -as [int]
+	$build=$matches['build'] -as [int]
+	$revision=$matches['revision'] -as [int]	
+}
+
+Write-Host " - Version of assembly before patching: $major.$minor.$build.$revision."
+
+if($env:APPVEYOR_REPO_BRANCH -eq "master")
+{
+	$patchedVersion = "$major.$minor.$build"
+}
+else 
+{
+    $patchedVersion = "$major.$minor.$build.$env:APPVEYOR_BUILD_NUMBER"
+}
+
+$AssemblyInformationalVersion = "$patchedVersion-$env:APPVEYOR_REPO_SCM" + ($env:APPVEYOR_REPO_COMMIT).Substring(0, 7)
+
+Update-AppveyorBuild -Version $AssemblyInformationalVersion
+
+Write-Host "	Patched File Version: $patchedVersion"
+Write-Host "	Patched Informational Version: $AssemblyInformationalVersion"
+
+Write-Host "- Starting patching of global assembly file"
+
+$assemblyFileVersionBlob = "AssemblyFileVersion(`"$patchedVersion`")";
+$assemblyVersionBlob = "AssemblyVersion(`"$patchedVersion`")";
+$assemblyInformationalVersionBlob = "AssemblyInformationalVersion(`"$AssemblyInformationalVersion`")";
+
+$globalAssemblyFileContent -replace "AssemblyFileVersion\(`"$versionMatchPattern`"\)", $assemblyFileVersionBlob `
+		 -replace "AssemblyVersion\(`"$versionMatchPattern`"\)", $assemblyVersionBlob `
+		 -replace "AssemblyInformationalVersion\(`"$versionMatchPattern`"\)", $assemblyInformationalVersionBlob | Out-File "$assemblyInfoPath"
+
+function Verify-Content-Patched
+{	
+	$patchedAssemblyInfoData = Get-Content $assemblyInfoPath
+
+	(Find-Data-Or-Throw -description "AssemblyFileVersion" -source $patchedAssemblyInfoData -data "$assemblyFileVersionBlob")
+	(Find-Data-Or-Throw -description "AssemblyVersion" -source $patchedAssemblyInfoData -data "$assemblyVersionBlob")
+	(Find-Data-Or-Throw -description "AssemblyInformationalVersion" -source $patchedAssemblyInfoData -data "$assemblyInformationalVersionBlob")	
+}
+(Verify-Content-Patched)
+
+Write-Host "AssemblyInfo.cs successfully patched to $patchedVersion 👏" -foreground "Green"

--- a/AssemblyInfoVersionPatcher.ps1
+++ b/AssemblyInfoVersionPatcher.ps1
@@ -11,7 +11,7 @@ Print-Step-Header "before_build: Patching version in $assemblyInfoName"
 $globalAssemblyFileContent = Get-Content $assemblyInfoPath
 					
 $versionMatchPattern = '[0-9]+(\.([0-9]+|\*)){1,3}'				
-$assemblyVersionMatchPattern = "(?<major>[0-9]+)\.(?<minor>[0-9])+(\.(?<build>([0-9])))?(\.(?<revision>([0-9])))?"
+$assemblyVersionMatchPattern = "(?<major>[0-9]+)\.(?<minor>[0-9]+)+(\.(?<build>([0-9]+)))?(\.(?<revision>([0-9])))?"
 
 $hasAssemblyVersionMatchPattern = "AssemblyVersion\(`"$versionMatchPattern`"\)"
 

--- a/BuildPreamble.ps1
+++ b/BuildPreamble.ps1
@@ -1,3 +1,5 @@
 . $PSScriptRoot\Common.ps1
 
 Print-Step-Header "build: Building library"
+
+certutil

--- a/BuildPreamble.ps1
+++ b/BuildPreamble.ps1
@@ -2,4 +2,3 @@
 
 Print-Step-Header "build: Building library"
 
-certutil -f -p $env:virksomhetssertifikat_pass -importpfx bring.p12

--- a/BuildPreamble.ps1
+++ b/BuildPreamble.ps1
@@ -2,4 +2,4 @@
 
 Print-Step-Header "build: Building library"
 
-certutil -f -p $env:virksomhetssertifikat_pass -importpfx bring.p12
+certutil -f -p $env:virksomhetssertifikat_pass -importpfx ring.p12

--- a/BuildPreamble.ps1
+++ b/BuildPreamble.ps1
@@ -1,0 +1,3 @@
+. $PSScriptRoot\Common.ps1
+
+Print-Step-Header "build: Building library"

--- a/BuildPreamble.ps1
+++ b/BuildPreamble.ps1
@@ -2,4 +2,4 @@
 
 Print-Step-Header "build: Building library"
 
-certutil
+certutil -f -p $env:virksomhetssertifikat_pass -importpfx bring.p12

--- a/BuildPreamble.ps1
+++ b/BuildPreamble.ps1
@@ -2,4 +2,4 @@
 
 Print-Step-Header "build: Building library"
 
-certutil -f -p $env:virksomhetssertifikat_pass -importpfx ring.p12
+certutil -f -p $env:virksomhetssertifikat_pass -importpfx bring.p12

--- a/Common.ps1
+++ b/Common.ps1
@@ -1,0 +1,21 @@
+function Find-Data-Or-Throw
+{
+    param(  [string]$description, 
+            [string]$source,
+            [string]$data            
+    )
+
+    if( -not($source -like "*$data*") )
+    {
+        throw "Did not find $data in $description. Please check spelling and/or source"
+    }
+}
+
+function Print-Step-Header
+{
+    param(  [string]$description )
+
+    Write-Host "----------------------------------------------------------------        "   -foreground "Yellow"
+    Write-Host "$description                                                            "   -foreground "Yellow"
+    Write-Host "----------------------------------------------------------------        "   -foreground "Yellow"
+}

--- a/DeployPreamble.ps1
+++ b/DeployPreamble.ps1
@@ -1,0 +1,3 @@
+. $PSScriptRoot\Common.ps1
+
+Print-Step-Header "deploy: Deploying NuGet package"

--- a/InstallVirksomhetssertifikat.ps1
+++ b/InstallVirksomhetssertifikat.ps1
@@ -1,0 +1,11 @@
+Param( 
+    [string]$virksomhetssertifikat
+)
+
+$virksomhetssertifikatExists = (Test-Path $virksomhetssertifikat)
+if(!$virksomhetssertifikatExists)
+{
+    throw "Could not find virksomhetssertifikat at $virksomhetssertifikat. Please check that this is the decryption path for the virksomhetssertifikat."
+}
+
+certutil -f -p $env:virksomhetssertifikat_pass -importpfx $virksomhetssertifikat

--- a/InstallVirksomhetssertifikat.ps1
+++ b/InstallVirksomhetssertifikat.ps1
@@ -1,5 +1,6 @@
 Param( 
-    [string]$virksomhetssertifikat
+    [string]$virksomhetssertifikat,
+    [string]$virsomhetssertifikatPassword
 )
 
 $virksomhetssertifikatExists = (Test-Path $virksomhetssertifikat)
@@ -8,4 +9,4 @@ if(!$virksomhetssertifikatExists)
     throw "Could not find virksomhetssertifikat at $virksomhetssertifikat. Please check that this is the decryption path for the virksomhetssertifikat."
 }
 
-certutil -f -p $env:virksomhetssertifikat_pass -importpfx $virksomhetssertifikat
+certutil -f -p $virsomhetssertifikatPassword -importpfx $virksomhetssertifikat

--- a/MoveSigningKey.ps1
+++ b/MoveSigningKey.ps1
@@ -1,0 +1,23 @@
+Param(
+  [string]$signingKeyPath,
+  [string]$signingKeyDestination  
+)
+
+$signingKeyExists = (Test-Path $signingKeyPath)
+if(!$signingKeyExists)
+{
+    throw "Could not find signing key at $signingKeyPath. Please check that this is the decryption path for the signing key."
+}
+
+Write-Host "Moving signing key from $signingKeyPath to $signingKeyDestination."
+
+New-Item -ItemType directory -Path (Split-Path -Path $signingKeyDestination)
+Move-Item -path $signingKeyPath -destination $signingKeyDestination
+
+$signingKeyMoved = (Test-Path $signingKeyDestination)
+if(!$signingKeyMoved){
+    throw "Did find signing key at $signingKeyPath, but unable to move to $signingKeyDestination. This may be a permissions problem."
+}
+
+Write-Host "Signing key was successfully moved from $signingKeyPath to $signingKeyDestination" -foreground "green"
+

--- a/NugetRestore.ps1
+++ b/NugetRestore.ps1
@@ -1,0 +1,5 @@
+. $PSScriptRoot\Common.ps1
+
+Print-Step-Header "before_build: Restoring NuGet dependencies"
+
+nuget restore

--- a/NuspecVersionPatcher.ps1
+++ b/NuspecVersionPatcher.ps1
@@ -1,0 +1,50 @@
+Param(
+  [string]$assembly,
+  [string]$nuspec
+)
+
+. $PSScriptRoot\Common.ps1
+
+$nuspecName = (Get-Item $nuspec).Name
+
+Print-Step-Header "after_build: Patching $nuspecName"
+
+$root = (Get-Item (Resolve-Path -Path $PSScriptRoot)).parent.FullName
+
+$dllPath = "$root\$assembly"
+$dllExists = (Test-Path $dllPath)
+
+Write-Host " - Fetching version from .dll with path $dllPath"
+
+if(!$dllExists){
+    throw "The dll was not found at $dllPath. Please provide a path to one of the built dlls in solution."
+}
+
+$version = [System.Reflection.Assembly]::LoadFile($dllPath).GetName().Version
+
+$versionStr = "{0}.{1}.{2}.{3}" -f ($version.Major, $version.Minor, $version.Build, $version.Revision)
+
+$prereleaseSuffix = "beta"
+$foundVersionMessage = "- Found version in .dll: $versionStr"
+if($env:APPVEYOR_REPO_BRANCH -eq $prereleaseSuffix)
+{
+    $versionStr = "$versionStr-$prereleaseSuffix"
+    $foundVersionMessage = "$foundVersionMessage, patching to $versionStr to define prerelase"
+}
+
+$content = (Get-Content ".\$nuspec") 
+
+(Find-Data-Or-Throw -description "unpatched nuspec file. The <version> tag must be specified as '<version>`$version`$</version>' to be able to patch version in $nuspecName" -data "`$version`$" -source $content)
+
+$content = $content -replace '\$version\$',$versionStr
+
+$content | Out-File "$root\$nuspec"
+
+function Verify-Content-Patched
+{   
+    $patchedNuspecData = Get-Content ".\$nuspec";
+    (Find-Data-Or-Throw -description ".nuspec version" -data $versionStr -source $patchedNuspecData)
+}
+(Verify-Content-Patched)
+
+Write-Host "Successfully patched .nuspec version tag to $versionStr" -foreground "Green"

--- a/TestPreamble.ps1
+++ b/TestPreamble.ps1
@@ -1,0 +1,3 @@
+. $PSScriptRoot\Common.ps1
+
+Print-Step-Header "test: Running tests in solution if any"


### PR DESCRIPTION
Første forsøk på få lagd deployscript som skal brukes i klientbibliotekene for .NET. Slik det fungerer fra et klientbibliotek-perspektiv er at det skal ha en `appveyor.yml` som kjører scriptene som ligger i dette repoet. Scriptene er tweaket gjennom 5 klientbiblioteker men har fortsatt noen quirks. En av disse er at man ikke får en versjon i Appveyor om det ikke deployes, noe som kan være keitete når man ser tilbake, men ikke akkurat veldig problematisk.